### PR TITLE
Fix `relative_path_made_absolute` test on Arch Linux

### DIFF
--- a/src/path/clean.rs
+++ b/src/path/clean.rs
@@ -158,7 +158,6 @@ mod tests {
     #[test]
     #[cfg(not(windows))]
     fn relative_path_made_absolute() {
-        let _ = PathBuf::from("/usr");
         let parent = PathBuf::from("/");
         let sibling = PathBuf::from("/etc");
         let descendent = PathBuf::from("/usr/bin");

--- a/src/path/clean.rs
+++ b/src/path/clean.rs
@@ -160,11 +160,11 @@ mod tests {
     fn relative_path_made_absolute() {
         let _ = PathBuf::from("/usr");
         let parent = PathBuf::from("/");
-        let sibling = PathBuf::from("/lib");
+        let sibling = PathBuf::from("/etc");
         let descendent = PathBuf::from("/usr/bin");
 
         check_make_abs_path(&Path::new("/usr/.."), parent);
-        check_make_abs_path(&Path::new("/usr/../lib"), sibling);
+        check_make_abs_path(&Path::new("/usr/../etc"), sibling);
         check_make_abs_path(&Path::new("/usr/../usr/bin"), descendent);
     }
 

--- a/src/path/clean.rs
+++ b/src/path/clean.rs
@@ -158,7 +158,7 @@ mod tests {
     #[test]
     #[cfg(not(windows))]
     fn relative_path_made_absolute() {
-        let pwd = PathBuf::from("/usr");
+        let _ = PathBuf::from("/usr");
         let parent = PathBuf::from("/");
         let sibling = PathBuf::from("/lib");
         let descendent = PathBuf::from("/usr/bin");


### PR DESCRIPTION
`/lib` symlinks to `/usr/lib` on Arch Linux, and the test traverses this symlink, causing it to fail. This PR switches `/lib` for `/etc`, which is less likely to be a symlink. It also removes an unused variable.